### PR TITLE
Support for billing address

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "business-mastery/omnipay-mobilpay",
+    "name": "lrauldan/omnipay-mobilpay",
     "description": "MobilPay driver for the Omnipay PHP payment processing library",
     "keywords": [
         "mobilpay",

--- a/src/BusinessMastery/Mobilpay/Api/Request/Card.php
+++ b/src/BusinessMastery/Mobilpay/Api/Request/Card.php
@@ -78,9 +78,11 @@ class Card extends AbstractRequest {
 		$xmlElem->nodeValue	= $this->signature;
 		$rootElem->appendChild($xmlElem);
 
-		$xmlElem			= $this->_xmlDoc->createElement('service');
-		$xmlElem->nodeValue	= $this->service;
-		$rootElem->appendChild($xmlElem);
+		if(isset($this->service)) {
+			$xmlElem			= $this->_xmlDoc->createElement('service');
+			$xmlElem->nodeValue	= $this->service;
+			$rootElem->appendChild($xmlElem);
+		}
 
 		$xmlElem			= $this->invoice->createXmlElement($this->_xmlDoc);
 		$rootElem->appendChild($xmlElem);

--- a/src/BusinessMastery/Mobilpay/Message/PurchaseRequest.php
+++ b/src/BusinessMastery/Mobilpay/Message/PurchaseRequest.php
@@ -7,6 +7,7 @@ use Omnipay\MobilPay\Exception\MissingKeyException;
 use Omnipay\MobilPay\Api\Request\Card;
 use Omnipay\MobilPay\Api\Invoice;
 use Omnipay\MobilPay\Api\Recurrence;
+use Omnipay\MobilPay\Api\Address;
 
 /**
  * MobilPay Purchase Request
@@ -231,9 +232,20 @@ class PurchaseRequest extends AbstractRequest {
         $request->invoice->currency = $this->getParameter('currency');
         $request->invoice->amount   = $this->getParameter('amount');
         $request->invoice->details  = $this->getParameter('details');
+        
+        if($this->getParameter('billingAddress')) {
+        	$addressData =  $this->getParameter('billingAddress');
+        	$billingAddress = new Address();
+        	
+        	foreach($addressData as $key => $value) {
+        		$billingAddress->$key = $value;
+        	}
+        	
+        	$request->invoice->setBillingAddress($billingAddress);
+        }
 
         $request->encrypt($this->getParameter('publicKey'));
-
+        
         $data = [
             'env_key' => $request->getEnvKey(),
             'data'    => $request->getEncData()
@@ -257,5 +269,21 @@ class PurchaseRequest extends AbstractRequest {
     public function sendData($data)
     {
         return $this->response = new PurchaseResponse($this, $data, $this->getEndpoint());
+    }
+    
+    /**
+     * @param unknown $address
+     */
+    public function setBillingAddress($address)
+    {
+    	return $this->setParameter('billingAddress', $address);
+    }
+    
+    /**
+     *
+     */
+    public function getBillingAddress()
+    {
+    	return $this->getParameter('billingAddress');
     }
 }

--- a/src/BusinessMastery/Mobilpay/Message/PurchaseRequest.php
+++ b/src/BusinessMastery/Mobilpay/Message/PurchaseRequest.php
@@ -7,6 +7,7 @@ use Omnipay\MobilPay\Exception\MissingKeyException;
 use Omnipay\MobilPay\Api\Request\Card;
 use Omnipay\MobilPay\Api\Invoice;
 use Omnipay\MobilPay\Api\Recurrence;
+use Omnipay\MobilPay\Api\Address;
 
 /**
  * MobilPay Purchase Request
@@ -231,9 +232,25 @@ class PurchaseRequest extends AbstractRequest {
         $request->invoice->currency = $this->getParameter('currency');
         $request->invoice->amount   = $this->getParameter('amount');
         $request->invoice->details  = $this->getParameter('details');
+        
+        if($this->getParameter('billingAddress')) {
+        	$addressData =  $this->getParameter('billingAddress');
+        	$billingAddress = new Address();
+        	
+        	foreach($addressData as $key => $value) {
+        		$billingAddress->$key = $value;
+        	}
+        	
+        	$request->invoice->setBillingAddress($billingAddress);
+        	$request->invoice->setShippingAddress($billingAddress);
+        }
+        
+        if(!$request->service) {
+        	unset($request->service);
+        } 
 
         $request->encrypt($this->getParameter('publicKey'));
-
+        
         $data = [
             'env_key' => $request->getEnvKey(),
             'data'    => $request->getEncData()
@@ -257,5 +274,21 @@ class PurchaseRequest extends AbstractRequest {
     public function sendData($data)
     {
         return $this->response = new PurchaseResponse($this, $data, $this->getEndpoint());
+    }
+    
+    /**
+     * @param unknown $address
+     */
+    public function setBillingAddress($address)
+    {
+    	return $this->setParameter('billingAddress', $address);
+    }
+    
+    /**
+     *
+     */
+    public function getBillingAddress()
+    {
+    	return $this->getParameter('billingAddress');
     }
 }


### PR DESCRIPTION
Pre-populate the request with the billing address. This feature will prevent mobilpay from asking the billing address again.
